### PR TITLE
fix(PW-86): adjusted z-index of dropdown-menu desktop

### DIFF
--- a/components/atoms/dropdown-nav-item.tsx
+++ b/components/atoms/dropdown-nav-item.tsx
@@ -46,7 +46,7 @@ const DropdownNavItem = ({
 
       <DropdownMenuContent
         align="center"
-        className="z-50"
+        className="z-[100]"
         sideOffset={1}
         style={{
           transition: "opacity 1s ease, transform 1s ease",

--- a/components/molecules/navbar.tsx
+++ b/components/molecules/navbar.tsx
@@ -178,7 +178,7 @@ function Navbar() {
       {/* <-- ==== Navbar Desktop Start ==== --> */}
       <nav
         className={cn(
-          "hidden lg:flex fixed top-0 left-0 right-0 items-center justify-between z-[100] w-full py-[22px] bg-white px-content-padding-lg 2xl:px-content-padding-2xl transition-all duration-200",
+          "hidden lg:flex fixed top-0 left-0 right-0 items-center justify-between z-[99] w-full py-[22px] bg-white px-content-padding-lg 2xl:px-content-padding-2xl transition-all duration-200",
           scrolled ? "bg-opacity-70 backdrop-blur-md" : "bg-opacity-100"
         )}
       >


### PR DESCRIPTION
Adjusted z-index of dropdown-menu on dekstop to ensure it overlays the navbar when i'ts being opened.