### PR TITLE
fix(PW-106): refine mark decorators

### DIFF
--- a/app/about-us/certification/page.tsx
+++ b/app/about-us/certification/page.tsx
@@ -1,7 +1,7 @@
 // Importing Data //
 import { client } from "@/sanity/lib/client";
 import { certificationQuery } from "@/sanity/services/certification-query";
-import { PortableText } from "next-sanity";
+import { PortableText } from "@portabletext/react";
 import { CertificationType } from "@/types/certification-type";
 
 // Import Components //
@@ -55,14 +55,15 @@ export default async function Certification() {
               style={{ backgroundColor: certification.backgroundColor }}
             >
               {/* Only render description if it's not null or undefined */}
-              {certification.description && (
-                <div className="text-white text-sm font-semibold text-center whitespace-pre-line">
-                  <PortableText
-                    value={certification.description}
-                    components={portableTextComponents}
-                  />
-                </div>
-              )}
+              {certification.description &&
+                Array.isArray(certification.description) && (
+                  <div className="text-white text-sm text-center whitespace-pre-line">
+                    <PortableText
+                      value={certification.description}
+                      components={portableTextComponents}
+                    />
+                  </div>
+                )}
               <p className="text-[28px] lg:text-[32px] font-aeonik-medium text-white text-center pb-1">
                 {certification.title}
               </p>

--- a/components/atoms/portable-text.tsx
+++ b/components/atoms/portable-text.tsx
@@ -21,34 +21,38 @@ const portableTextComponents: Partial<PortableTextReactComponents> = {
         case "h6":
           return <h6 className="text-base font-normal">{value.children}</h6>;
         default:
+          // Handle paragraphs (default text blocks)
           return (
             <p>
-              {value.children.map((child: any, index: number) => (
-                <span key={index}>
-                  {child.marks && child.marks.includes("strong") ? (
-                    <strong>{child.text}</strong>
-                  ) : child.marks && child.marks.includes("em") ? (
-                    <em>{child.text}</em>
-                  ) : child.marks && child.marks.includes("strike-through") ? (
-                    <s>{child.text}</s>
-                  ) : child.marks && child.marks.includes("code") ? (
-                    <code className="bg-gray-200 text-red-600 p-1 rounded">
-                      {child.text}
-                    </code>
-                  ) : (
-                    child.text
-                  )}
-                </span>
-              ))}
+              {value.children.map((child: any, index: number) => {
+                if (typeof child === "string") {
+                  return <span key={index}>{child}</span>;
+                }
+                return (
+                  <span key={index}>
+                    {child.marks && child.marks.includes("strong") ? (
+                      <strong>{child.text}</strong>
+                    ) : child.marks && child.marks.includes("em") ? (
+                      <em>{child.text}</em>
+                    ) : child.marks && child.marks.includes("underline") ? (
+                      <u>{child.text}</u> // Underline support here
+                    ) : child.marks &&
+                      child.marks.includes("strike-through") ? (
+                      <s>{child.text}</s>
+                    ) : child.marks && child.marks.includes("code") ? (
+                      <code className="bg-gray-200 text-red-600 p-1 rounded">
+                        {child.text}
+                      </code>
+                    ) : (
+                      child.text
+                    )}
+                  </span>
+                );
+              })}
             </p>
           );
       }
     },
-    listItem: ({ value }: PortableTextTypeComponentProps<any>) => (
-      <li className="ml-4 list-disc">
-        {value.children.map((child: any, index: number) => child.text)}
-      </li>
-    ),
   },
   list: {
     bullet: ({ children }: any) => (
@@ -61,6 +65,9 @@ const portableTextComponents: Partial<PortableTextReactComponents> = {
     ),
     em: ({ children }: PortableTextMarkComponentProps<any>) => (
       <em className="italic">{children}</em>
+    ),
+    underline: ({ children }: PortableTextMarkComponentProps<any>) => (
+      <u className="underline">{children}</u> // Underline support added here
     ),
     strikeThrough: ({ children }: PortableTextMarkComponentProps<any>) => (
       <s>{children}</s>

--- a/sanity/schemaTypes/certification.ts
+++ b/sanity/schemaTypes/certification.ts
@@ -53,6 +53,11 @@ export const CertificationType = defineType({
         {
           type: "block",
           marks: {
+            decorators: [
+              { title: "Bold", value: "strong" },
+              { title: "Italic", value: "em" },
+              { title: "Underline", value: "underline" },
+            ],
             annotations: [],
           },
         },

--- a/sanity/services/certification-query.ts
+++ b/sanity/services/certification-query.ts
@@ -2,12 +2,7 @@ export const certificationQuery = `
   *[_type == "certification"]{
     title,
     position,
-    description[] {
-      ...,
-      children[]{
-        text
-      }
-    },
+    description[],
     "backgroundColor": backgroundColor.hex,
     _createdAt,
     _updatedAt


### PR DESCRIPTION
Ensured consistent rendering of text marks decorators including strong, em, underline, strike-through, and code.